### PR TITLE
Config typo and run directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ puma::app {'myapp':
     init_active_record => false,
     preload_app        => true,
     rails_env          => 'production',
-    rvm_ruby           => 'ruby-2.0.0-p0,
+    rvm_ruby           => 'ruby-2.0.0-p0',
     restart_command    => 'puma',
 }
 

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -76,8 +76,7 @@ define puma::app (
 				env 		=> $env,
 				exec            => "$ruby_exec_prefix bundle exec puma -C $puma_config_path",
 				require		=> File[$puma_config_path],
-                                pre_start       => [ "sudo mkdir -p $puma_pid_path",
-                                                     "sudo chown -R $puma_user:$puma_user $puma_pid_path" ]
+                                pre_start       => "sudo mkdir -p $puma_pid_path\nsudo chown -R $puma_user:$puma_user $puma_pid_path"
 			}
 			$puma_daemonize = false # this is important
 									#  - upstart does NOT play well with doing your own

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -76,7 +76,7 @@ define puma::app (
 				env 		=> $env,
 				exec            => "$ruby_exec_prefix bundle exec puma -C $puma_config_path",
 				require		=> File[$puma_config_path],
-                                pre_start       => "sudo mkdir -p $puma_pid_path\nsudo chown -R $puma_user:$puma_user $puma_pid_path"
+                                pre_start       => "sudo mkdir -p $puma_pid_path\nsudo chown -R $puma_user:$puma_user $puma_pid_path\n"
 			}
 			$puma_daemonize = false # this is important
 									#  - upstart does NOT play well with doing your own

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -61,7 +61,6 @@ define puma::app (
 		ensure => directory,
 		mode => 'a+x',
 	})
-	
 
 	case $puma::service_type {
 		'upstart': {
@@ -77,6 +76,8 @@ define puma::app (
 				env 		=> $env,
 				exec            => "$ruby_exec_prefix bundle exec puma -C $puma_config_path",
 				require		=> File[$puma_config_path],
+                                pre_start       => [ "sudo mkdir -p $puma_pid_path",
+                                                     "sudo chown -R $puma_user:$puma_user $puma_pid_path" ]
 			}
 			$puma_daemonize = false # this is important
 									#  - upstart does NOT play well with doing your own

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -14,6 +14,7 @@ define puma::app (
     $restart_command    = $puma::restart_command,
 ) {
 	$puma_pid_path		= sprintf($puma::puma_pid_path_spf, $app_name)
+        $puma_pid_dir           = dirname($puma_pid_path)
 	$puma_socket_path	= sprintf($puma::puma_socket_path_spf, $app_name)
 	$puma_config_path	= sprintf($puma::puma_config_path_spf, $app_name)
 	$puma_stdout_log_path = sprintf($puma::puma_stdout_log_path_spf, $app_name)
@@ -76,7 +77,7 @@ define puma::app (
 				env 		=> $env,
 				exec            => "$ruby_exec_prefix bundle exec puma -C $puma_config_path",
 				require		=> File[$puma_config_path],
-                                pre_start       => "sudo mkdir -p $puma_pid_path\nsudo chown -R $puma_user:$puma_user $puma_pid_path\n"
+                                pre_start       => "sudo mkdir -p $puma_pid_dir\nsudo chown -R $puma_user:$puma_user $puma_pid_dir\n"
 			}
 			$puma_daemonize = false # this is important
 									#  - upstart does NOT play well with doing your own

--- a/templates/app_init_script.erb
+++ b/templates/app_init_script.erb
@@ -20,16 +20,13 @@ DAEMON_OPTS="-C <%= @puma_config_path %>"
 # PID_PATH="<%= @puma_pid_path %>"
 SOCKET_PATH="<%= @puma_socket_path %>"
 WEB_SERVER_PID="<%= @puma_pid_path %>"
-# SIDEKIQ_PID="$PID_PATH/sidekiq.pid"
-# STOP_SIDEKIQ="RAILS_ENV=production bundle exec rake sidekiq:stop"
-# START_SIDEKIQ="RAILS_ENV=production bundle exec rake sidekiq:start"
+RUNDIR=$(dirname "${WEB_SERVER_PID}")
 NAME="<%= @app_name %>"
 DESC="<%= @app_name %>"
 
 check_pid(){
   if [ -f $WEB_SERVER_PID ]; then
     PID=`cat $WEB_SERVER_PID`
-    # SPID=`cat $SIDEKIQ_PID`
     STATUS=`ps aux | grep $PID | grep -v grep | wc -l`
   else
     STATUS=0
@@ -50,12 +47,15 @@ start() {
     exit 1
   else
     if [ `whoami` = root ]; then
-        if [ -f "$SOCKET_PATH/puma.sock" ]; then
-            execute "rm $SOCKET_PATH/puma.sock"
-        fi
-        execute "bundle exec puma $DAEMON_OPTS"
-        # execute "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
-        echo "$DESC started"
+      mkdir -p $RUNDIR
+      touch $WEB_SERVER_PID
+      chown <%= @puma_user %>:<%= @puma_user %> $RUNDIR $WEB_SERVER_PID
+      chmod 755 $RUNDIR
+      if [ -f "$SOCKET_PATH/puma.sock" ]; then
+          execute "rm $SOCKET_PATH/puma.sock"
+      fi
+      execute "bundle exec puma $DAEMON_OPTS"
+      echo "$DESC started"
     fi
   fi
 }
@@ -66,7 +66,6 @@ stop() {
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     ## Program is running, stop it.
     kill -QUIT `cat $WEB_SERVER_PID`
-    # execute "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
     rm "$WEB_SERVER_PID" >> /dev/null
     echo "$DESC stopped"
   else
@@ -82,10 +81,6 @@ restart() {
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "Restarting $DESC..."
     kill -USR2 `cat $WEB_SERVER_PID`
-    # execute "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
-    # if [ `whoami` = root ]; then
-    #   execute "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
-    # fi
     echo "$DESC restarted."
   else
     echo "Error, $NAME not running!"
@@ -98,7 +93,6 @@ status() {
   check_pid
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "$DESC / Puma with PID $PID is running."
-    # echo "$DESC / Sidekiq with PID $SPID is running."
   else
     echo "$DESC is not running."
     exit 1

--- a/templates/puma.rb.erb
+++ b/templates/puma.rb.erb
@@ -34,7 +34,7 @@ pidfile "<%= @puma_pid_path %>"
 # (“append”) specifies whether the output is appended, the default is
 # “false”.
 #
-stdout_redirect "<%= @puma_stdout_log_path %>", "<%= @puma_stderr_log_path %>"
+stdout_redirect "<%= @puma_stderr_log_path %>", "<%= @puma_stdout_log_path %>"
 
 # Disable request logging.
 #


### PR DESCRIPTION
Add pre-start section in upstart configuration, to ensure run directory is created and owned by the app's user. Update init.d script to also manage run directory. Note that init.d script has _not_ been tested. This change addresses the issue of puma not restarting after system reboot.
Fix README typo; change log file config in an attempt to direct the expected output to an intuitive file destination. Remove references to Sidekiq.
